### PR TITLE
add WASM-powered website version of pdate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+---
+name: Deploy
+
+"on":
+  push:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-www:
+    name: Deploy WWW
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build WASM
+        run: make wasm
+      - name: Login to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+      - name: Deploy
+        env:
+          RSYNC_PASSWORD: ${{ secrets.RSYNC_PASSWORD }}
+        run: |
+          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.tailnet-003a.ts.net/pdate.dzdz.cz/
+
+  ntfy:
+    name: Ntfy
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    needs: [deploy-www]
+    steps:
+      - name: Send success notification
+        uses: niniyas/ntfy-action@master
+        if: ${{ !contains(needs.*.result, 'failure') }}
+        with:
+          url: "https://ntfy.cdzombak.net"
+          topic: "dotcom-deploys"
+          priority: 3
+          headers: '{"authorization": "Bearer ${{ secrets.NTFY_TOKEN }}"}'
+          tags: white_check_mark
+          title: ${{ github.event.repository.name }} deployed
+          details: cdzombak/${{ github.event.repository.name }} updated to ${{ github.sha }}
+      - name: Send failure notification
+        uses: niniyas/ntfy-action@master
+        if: ${{ contains(needs.*.result, 'failure') }}
+        with:
+          url: "https://ntfy.cdzombak.net"
+          topic: "gha-builds"
+          priority: 3
+          headers: '{"authorization": "Bearer ${{ secrets.NTFY_TOKEN }}"}'
+          tags: no_entry
+          title: ${{ github.event.repository.name }} deploy failed
+          details: deploy failed for cdzombak/${{ github.event.repository.name }} ${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 out/
+www/pdate.wasm
+www/wasm_exec.js

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ package: all ## Build all binaries + .deb packages to ./out (requires fpm: https
 .PHONY: wasm
 wasm: www/pdate.wasm www/wasm_exec.js ## Build WebAssembly binary for web interface
 
-www/pdate.wasm: wasm.go parse.go
-	GOOS=js GOARCH=wasm go build -o www/pdate.wasm wasm.go parse.go
+www/pdate.wasm: wasm.go parse.go timeago_config.go
+	GOOS=js GOARCH=wasm go build -o www/pdate.wasm wasm.go parse.go timeago_config.go
 
 www/wasm_exec.js:
 	@if [ -f "$$(go env GOROOT)/misc/wasm/wasm_exec.js" ]; then \

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+//go:build !js && !wasm
+// +build !js,!wasm
+
 package main
 
 import (

--- a/wasm.go
+++ b/wasm.go
@@ -1,0 +1,167 @@
+//go:build js && wasm
+// +build js,wasm
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"syscall/js"
+	"time"
+)
+
+// parseDate is the WASM-exported function that parses a datetime string
+func parseDate(this js.Value, args []js.Value) interface{} {
+	if len(args) != 1 {
+		return map[string]interface{}{
+			"error": "expected 1 argument: datetime string",
+		}
+	}
+
+	input := args[0].String()
+	parsed, err := Parse(input)
+	if err != nil {
+		return map[string]interface{}{
+			"error": err.Error(),
+		}
+	}
+
+	localLoc, err := time.LoadLocation("Local")
+	if err != nil {
+		localLoc = time.UTC
+	}
+	parsedLocal := parsed.In(localLoc)
+
+	// Get timezone name and offset
+	zoneName, offset := parsedLocal.Zone()
+	offsetHours := offset / 3600
+	offsetMins := (offset % 3600) / 60
+	timezoneStr := fmt.Sprintf("%s (UTC%+d:%02d)", zoneName, offsetHours, offsetMins)
+
+	result := map[string]interface{}{
+		"success": true,
+		"input":   input,
+		"parsed":  parsed.Format("2006-01-02 15:04:05 MST"),
+		"utc": map[string]interface{}{
+			"formatted":     parsed.Format("2006-01-02 3:04:05 PM"),
+			"rfc3339":       parsed.Format(time.RFC3339),
+			"rfc1123z":      parsed.Format(time.RFC1123Z),
+			"unix":          parsed.Unix(),
+			"unixMilli":     parsed.UnixMilli(),
+			"unixNano":      parsed.UnixNano(),
+			"iso8601":       parsed.Format("2006-01-02T15:04:05Z"),
+		},
+		"local": map[string]interface{}{
+			"formatted": parsedLocal.Format("2006-01-02 3:04:05 PM MST"),
+			"timezone":  timezoneStr,
+		},
+	}
+
+	// Add relative time
+	relativeTime := formatRelativeTime(parsed)
+	result["relative"] = map[string]interface{}{
+		"formatted": relativeTime,
+	}
+
+	return result
+}
+
+// formatRelativeTime formats a time as a relative string (e.g., "5 minutes ago")
+// This matches the logic from timeago_config.go
+func formatRelativeTime(t time.Time) string {
+	now := time.Now()
+	diff := now.Sub(t)
+
+	const (
+		second = time.Second
+		minute = time.Minute
+		hour   = time.Hour
+		day    = 24 * time.Hour
+		month  = 30 * day
+		year   = 365 * day
+	)
+
+	// Maximum relative time is 13 months
+	maxDuration := 13 * month
+	if diff > maxDuration || diff < -maxDuration {
+		return t.Format("2006-01-02 15:04:05 MST")
+	}
+
+	isPast := diff >= 0
+	if !isPast {
+		diff = -diff
+	}
+
+	var value int
+	var unit string
+
+	switch {
+	case diff < minute:
+		value = int(diff / second)
+		if value <= 1 {
+			unit = "about a second"
+		} else {
+			return formatTimeString(value, "seconds", isPast)
+		}
+	case diff < hour:
+		value = int(diff / minute)
+		if value == 1 {
+			unit = "about a minute"
+		} else {
+			return formatTimeString(value, "minutes", isPast)
+		}
+	case diff < day:
+		value = int(diff / hour)
+		if value == 1 {
+			unit = "about an hour"
+		} else {
+			return formatTimeString(value, "hours", isPast)
+		}
+	case diff < month:
+		value = int(diff / day)
+		if value == 1 {
+			unit = "one day"
+		} else {
+			return formatTimeString(value, "days", isPast)
+		}
+	case diff < year:
+		value = int(math.Round(float64(diff) / float64(month)))
+		if value == 1 {
+			unit = "one month"
+		} else {
+			return formatTimeString(value, "months", isPast)
+		}
+	default:
+		value = int(math.Round(float64(diff) / float64(year)))
+		if value == 1 {
+			unit = "one year"
+		} else {
+			return formatTimeString(value, "years", isPast)
+		}
+	}
+
+	if isPast {
+		return unit + " ago"
+	}
+	return "in " + unit
+}
+
+func formatTimeString(value int, unit string, isPast bool) string {
+	result := fmt.Sprintf("%d %s", value, unit)
+	if isPast {
+		return result + " ago"
+	}
+	return "in " + result
+}
+
+func main() {
+	// Keep the program running
+	c := make(chan struct{})
+
+	// Register the parseDate function to be callable from JavaScript
+	js.Global().Set("pdateParse", js.FuncOf(parseDate))
+
+	fmt.Println("pdate WASM module loaded")
+
+	<-c
+}

--- a/www/README.md
+++ b/www/README.md
@@ -1,0 +1,47 @@
+# pdate Web Interface
+
+A WebAssembly-powered web interface for parsing datetime strings and ULIDs.
+
+## Building
+
+From the project root directory:
+
+```bash
+make wasm
+```
+
+This will:
+1. Compile the Go code to WebAssembly (`pdate.wasm`)
+2. Copy the required `wasm_exec.js` file from your Go installation
+
+## Running Locally
+
+From the project root directory:
+
+```bash
+make serve
+```
+
+Then open your browser to http://localhost:8080
+
+## Usage
+
+1. Enter a datetime string, Unix timestamp, or ULID in the input field
+2. Click "Parse" or press Enter
+3. View the parsed results in various formats
+
+### Supported Input Formats
+
+- Unix timestamps (seconds, milliseconds, microseconds, nanoseconds)
+- Unix timestamps with fractional seconds (e.g., `1705318200.5`)
+- ISO 8601 / RFC3339 (e.g., `2024-01-15T10:30:00Z`)
+- Various other datetime formats
+- ULIDs (e.g., `01HQVXYZ1234567890ABCDEFGH`)
+
+## Files
+
+- `index.html` - Main HTML page
+- `styles.css` - Styling
+- `app.js` - JavaScript application logic
+- `pdate.wasm` - Compiled WebAssembly binary (generated)
+- `wasm_exec.js` - Go WASM runtime support (copied from Go installation)

--- a/www/app.js
+++ b/www/app.js
@@ -1,0 +1,195 @@
+// Global state
+let wasmLoaded = false;
+let pdateParse = null;
+
+// DOM elements
+const input = document.getElementById('datetime-input');
+const parseBtn = document.getElementById('parse-btn');
+const clearBtn = document.getElementById('clear-btn');
+const nowBtn = document.getElementById('now-btn');
+const loading = document.getElementById('loading');
+const error = document.getElementById('error');
+const results = document.getElementById('results');
+
+// Show loading spinner initially
+loading.classList.remove('hidden');
+
+// Initialize WASM
+async function initWasm() {
+    try {
+        const go = new Go();
+        const result = await WebAssembly.instantiateStreaming(
+            fetch('pdate.wasm'),
+            go.importObject
+        );
+
+        // Run the Go program
+        go.run(result.instance);
+
+        // Wait a bit for the Go program to register the function
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Check if the function is available
+        if (typeof window.pdateParse === 'function') {
+            pdateParse = window.pdateParse;
+            wasmLoaded = true;
+            loading.classList.add('hidden');
+            console.log('pdate WASM module loaded successfully');
+            // Focus the input field once WASM is loaded
+            input.focus();
+        } else {
+            throw new Error('pdateParse function not found');
+        }
+    } catch (err) {
+        console.error('Failed to load WASM module:', err);
+        loading.classList.add('hidden');
+        showError(`Failed to load WASM module: ${err.message}`);
+    }
+}
+
+// Show error message
+function showError(message) {
+    error.textContent = message;
+    error.classList.remove('hidden');
+    results.classList.add('hidden');
+}
+
+// Hide error message
+function hideError() {
+    error.classList.add('hidden');
+}
+
+// Display results
+function displayResults(data) {
+    hideError();
+
+    // Input section
+    document.getElementById('result-input').textContent = data.input;
+    document.getElementById('result-parsed').textContent = data.parsed;
+
+    // UTC section
+    document.getElementById('result-utc-formatted').textContent = data.utc.formatted;
+    document.getElementById('result-utc-rfc3339').textContent = data.utc.rfc3339;
+    document.getElementById('result-utc-rfc1123z').textContent = data.utc.rfc1123z;
+    document.getElementById('result-utc-unix').textContent = data.utc.unix;
+    document.getElementById('result-utc-unix-milli').textContent = data.utc.unixMilli;
+    document.getElementById('result-utc-unix-nano').textContent = data.utc.unixNano;
+
+    // Local section
+    document.getElementById('result-local-formatted').textContent = data.local.formatted;
+    document.getElementById('result-local-timezone').textContent = data.local.timezone;
+
+    // Relative section
+    document.getElementById('result-relative-formatted').textContent = data.relative.formatted;
+
+    results.classList.remove('hidden');
+}
+
+// Parse datetime
+function parseDateTime() {
+    if (!wasmLoaded) {
+        showError('WASM module is still loading. Please wait...');
+        return;
+    }
+
+    const value = input.value.trim();
+    if (!value) {
+        showError('Please enter a datetime string or ULID');
+        return;
+    }
+
+    try {
+        const result = pdateParse(value);
+
+        if (result.error) {
+            showError(`Parse error: ${result.error}`);
+        } else {
+            displayResults(result);
+        }
+    } catch (err) {
+        showError(`Unexpected error: ${err.message}`);
+    }
+}
+
+// Clear input and results
+function clearAll() {
+    input.value = '';
+    hideError();
+    results.classList.add('hidden');
+    input.focus();
+}
+
+// Use current time
+function useNow() {
+    // Get current Unix timestamp
+    const now = Math.floor(Date.now() / 1000);
+    input.value = now.toString();
+    parseDateTime();
+}
+
+// Event listeners
+parseBtn.addEventListener('click', parseDateTime);
+clearBtn.addEventListener('click', clearAll);
+nowBtn.addEventListener('click', useNow);
+
+input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+        parseDateTime();
+    }
+});
+
+// Copy to clipboard functionality
+function setupCopyButtons() {
+    document.querySelectorAll('.copy-btn').forEach(button => {
+        button.addEventListener('click', async (e) => {
+            const targetId = button.getAttribute('data-copy-target');
+            const targetElement = document.getElementById(targetId);
+
+            if (!targetElement) return;
+
+            const textToCopy = targetElement.textContent;
+
+            try {
+                await navigator.clipboard.writeText(textToCopy);
+
+                // Visual feedback
+                button.classList.add('copied');
+                const originalTitle = button.getAttribute('title');
+                button.setAttribute('title', 'Copied!');
+
+                // Reset after 2 seconds
+                setTimeout(() => {
+                    button.classList.remove('copied');
+                    button.setAttribute('title', originalTitle);
+                }, 2000);
+            } catch (err) {
+                console.error('Failed to copy:', err);
+                // Fallback for browsers that don't support clipboard API
+                const textArea = document.createElement('textarea');
+                textArea.value = textToCopy;
+                textArea.style.position = 'fixed';
+                textArea.style.left = '-999999px';
+                document.body.appendChild(textArea);
+                textArea.select();
+                try {
+                    document.execCommand('copy');
+                    button.classList.add('copied');
+                    setTimeout(() => button.classList.remove('copied'), 2000);
+                } catch (fallbackErr) {
+                    console.error('Fallback copy failed:', fallbackErr);
+                }
+                document.body.removeChild(textArea);
+            }
+        });
+    });
+}
+
+// Initialize WASM on page load
+initWasm();
+
+// Setup copy buttons after results are displayed
+const originalDisplayResults = displayResults;
+displayResults = function(data) {
+    originalDisplayResults(data);
+    setupCopyButtons();
+};

--- a/www/app.js
+++ b/www/app.js
@@ -138,58 +138,50 @@ input.addEventListener('keydown', (e) => {
     }
 });
 
-// Copy to clipboard functionality
-function setupCopyButtons() {
-    document.querySelectorAll('.copy-btn').forEach(button => {
-        button.addEventListener('click', async (e) => {
-            const targetId = button.getAttribute('data-copy-target');
-            const targetElement = document.getElementById(targetId);
+// Copy to clipboard functionality using event delegation
+results.addEventListener('click', async (e) => {
+    const button = e.target.closest('.copy-btn');
+    if (!button) return;
 
-            if (!targetElement) return;
+    const targetId = button.getAttribute('data-copy-target');
+    const targetElement = document.getElementById(targetId);
 
-            const textToCopy = targetElement.textContent;
+    if (!targetElement) return;
 
-            try {
-                await navigator.clipboard.writeText(textToCopy);
+    const textToCopy = targetElement.textContent;
 
-                // Visual feedback
-                button.classList.add('copied');
-                const originalTitle = button.getAttribute('title');
-                button.setAttribute('title', 'Copied!');
+    try {
+        await navigator.clipboard.writeText(textToCopy);
 
-                // Reset after 2 seconds
-                setTimeout(() => {
-                    button.classList.remove('copied');
-                    button.setAttribute('title', originalTitle);
-                }, 2000);
-            } catch (err) {
-                console.error('Failed to copy:', err);
-                // Fallback for browsers that don't support clipboard API
-                const textArea = document.createElement('textarea');
-                textArea.value = textToCopy;
-                textArea.style.position = 'fixed';
-                textArea.style.left = '-999999px';
-                document.body.appendChild(textArea);
-                textArea.select();
-                try {
-                    document.execCommand('copy');
-                    button.classList.add('copied');
-                    setTimeout(() => button.classList.remove('copied'), 2000);
-                } catch (fallbackErr) {
-                    console.error('Fallback copy failed:', fallbackErr);
-                }
-                document.body.removeChild(textArea);
-            }
-        });
-    });
-}
+        // Visual feedback
+        button.classList.add('copied');
+        const originalTitle = button.getAttribute('title');
+        button.setAttribute('title', 'Copied!');
+
+        // Reset after 2 seconds
+        setTimeout(() => {
+            button.classList.remove('copied');
+            button.setAttribute('title', originalTitle);
+        }, 2000);
+    } catch (err) {
+        console.error('Failed to copy:', err);
+        // Fallback for browsers that don't support clipboard API
+        const textArea = document.createElement('textarea');
+        textArea.value = textToCopy;
+        textArea.style.position = 'fixed';
+        textArea.style.left = '-999999px';
+        document.body.appendChild(textArea);
+        textArea.select();
+        try {
+            document.execCommand('copy');
+            button.classList.add('copied');
+            setTimeout(() => button.classList.remove('copied'), 2000);
+        } catch (fallbackErr) {
+            console.error('Fallback copy failed:', fallbackErr);
+        }
+        document.body.removeChild(textArea);
+    }
+});
 
 // Initialize WASM on page load
 initWasm();
-
-// Setup copy buttons after results are displayed
-const originalDisplayResults = displayResults;
-displayResults = function(data) {
-    originalDisplayResults(data);
-    setupCopyButtons();
-};

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>pdate - DateTime Parser</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>pdate</h1>
+            <p class="subtitle">Parse datetime strings and ULIDs</p>
+        </header>
+
+        <main>
+            <div class="input-section">
+                <label for="datetime-input">Enter datetime string or ULID:</label>
+                <div class="input-group">
+                    <input
+                        type="text"
+                        id="datetime-input"
+                        placeholder="e.g., 2024-01-15T10:30:00Z, 1705318200, 01HQVXYZ..."
+                        autofocus
+                    >
+                    <button id="parse-btn">Parse</button>
+                    <button id="clear-btn">Clear</button>
+                </div>
+                <button id="now-btn">Use Current Time</button>
+            </div>
+
+            <div id="loading" class="loading hidden">
+                <div class="spinner"></div>
+                <p>Loading WASM module...</p>
+            </div>
+
+            <div id="error" class="error hidden"></div>
+
+            <div id="results" class="results hidden">
+                <div class="result-section">
+                    <h2>Input</h2>
+                    <div class="result-item">
+                        <span class="label">Original:</span>
+                        <span class="value" id="result-input"></span>
+                        <button class="copy-btn" data-copy-target="result-input" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">Parsed as:</span>
+                        <span class="value" id="result-parsed"></span>
+                        <button class="copy-btn" data-copy-target="result-parsed" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <p class="verify-text">Please verify this matches your input/expectations</p>
+                </div>
+
+                <div class="result-section">
+                    <h2>UTC</h2>
+                    <div class="result-item">
+                        <span class="label">Formatted:</span>
+                        <span class="value" id="result-utc-formatted"></span>
+                        <button class="copy-btn" data-copy-target="result-utc-formatted" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">RFC3339:</span>
+                        <span class="value" id="result-utc-rfc3339"></span>
+                        <button class="copy-btn" data-copy-target="result-utc-rfc3339" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">RFC1123Z:</span>
+                        <span class="value" id="result-utc-rfc1123z"></span>
+                        <button class="copy-btn" data-copy-target="result-utc-rfc1123z" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">Unix (seconds):</span>
+                        <span class="value" id="result-utc-unix"></span>
+                        <button class="copy-btn" data-copy-target="result-utc-unix" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">Unix (millis):</span>
+                        <span class="value" id="result-utc-unix-milli"></span>
+                        <button class="copy-btn" data-copy-target="result-utc-unix-milli" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">Unix (nanos):</span>
+                        <span class="value" id="result-utc-unix-nano"></span>
+                        <button class="copy-btn" data-copy-target="result-utc-unix-nano" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="result-section">
+                    <h2>Local Time</h2>
+                    <div class="result-item">
+                        <span class="label">Formatted:</span>
+                        <span class="value" id="result-local-formatted"></span>
+                        <button class="copy-btn" data-copy-target="result-local-formatted" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="result-item">
+                        <span class="label">Timezone:</span>
+                        <span class="value" id="result-local-timezone"></span>
+                        <button class="copy-btn" data-copy-target="result-local-timezone" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="result-section">
+                    <h2>Relative</h2>
+                    <div class="result-item">
+                        <span class="label">Time ago:</span>
+                        <span class="value" id="result-relative-formatted"></span>
+                        <button class="copy-btn" data-copy-target="result-relative-formatted" title="Copy to clipboard">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <footer>
+            <p>Powered by <a href="https://webassembly.org/" target="_blank">WebAssembly</a></p>
+        </footer>
+    </div>
+
+    <script src="wasm_exec.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/www/index.html
+++ b/www/index.html
@@ -10,7 +10,7 @@
     <div class="container">
         <header>
             <h1>pdate</h1>
-            <p class="subtitle">Parse datetime strings and ULIDs</p>
+            <p class="subtitle">Parse date/time strings, Unix timestamps, ULIDs, etc.</p>
         </header>
 
         <main>
@@ -59,7 +59,7 @@
                             </svg>
                         </button>
                     </div>
-                    <p class="verify-text">Please verify this matches your input/expectations</p>
+                    <p class="verify-text">Please verify this matches your input/expectations.</p>
                 </div>
 
                 <div class="result-section">
@@ -167,7 +167,7 @@
         </main>
 
         <footer>
-            <p>Powered by <a href="https://webassembly.org/" target="_blank">WebAssembly</a></p>
+            <p>Powered by <a href="https://github.com/cdzombak/pdate?tab=readme-ov-file">pdate</a> by <a href="https://www.dzombak.com">Chris Dzombak</a></p>
         </footer>
     </div>
 

--- a/www/index.html
+++ b/www/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>pdate - DateTime Parser</title>
     <link rel="stylesheet" href="styles.css">
+    <script defer src="https://ua.cdzombak.net/script.js" data-website-id="078dfe69-6d9b-4d22-9225-39dd25e225fa"></script>
 </head>
 <body>
     <div class="container">

--- a/www/styles.css
+++ b/www/styles.css
@@ -180,14 +180,22 @@ button:active {
 @media (min-width: 1100px) {
     .results {
         grid-template-columns: repeat(2, 1fr);
+        grid-auto-rows: auto;
     }
+
+    /* Explicit grid placement for horizontal alignment */
+    .result-section:nth-child(1) { grid-column: 1; grid-row: 1; } /* Input */
+    .result-section:nth-child(2) { grid-column: 1; grid-row: 2; } /* UTC */
+    .result-section:nth-child(3) { grid-column: 2; grid-row: 1; } /* Local Time */
+    .result-section:nth-child(4) { grid-column: 2; grid-row: 2; } /* Relative */
 }
 
 .result-section {
     background: var(--bg-secondary);
-    padding: 1.5rem;
+    padding: 1.5rem 1.5rem 1rem;
     border-radius: 12px;
     border: 1px solid var(--border);
+    height: fit-content;
 }
 
 .result-section h2 {
@@ -261,6 +269,7 @@ button:active {
 
 .verify-text {
     margin-top: 0.5rem;
+    margin-bottom: 0;
     font-size: 0.9rem;
     color: var(--text-secondary);
     font-style: italic;

--- a/www/styles.css
+++ b/www/styles.css
@@ -1,0 +1,311 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --bg-primary: #0f0f0f;
+    --bg-secondary: #1a1a1a;
+    --bg-tertiary: #262626;
+    --text-primary: #e0e0e0;
+    --text-secondary: #a0a0a0;
+    --accent: #4a9eff;
+    --accent-hover: #6bb0ff;
+    --error: #ff4444;
+    --success: #44ff44;
+    --border: #333333;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 2rem 2rem;
+}
+
+header {
+    text-align: center;
+    margin-bottom: 3rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 2px solid var(--border);
+}
+
+h1 {
+    font-size: 3rem;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: 0.5rem;
+    font-family: monospace;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+}
+
+.input-section {
+    background: var(--bg-secondary);
+    padding: 2rem;
+    border-radius: 12px;
+    margin-bottom: 2rem;
+    border: 1px solid var(--border);
+    max-width: 100%;
+}
+
+label {
+    display: block;
+    margin-bottom: 0.75rem;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.input-group {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+input[type="text"] {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    background: var(--bg-tertiary);
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-family: monospace;
+    transition: border-color 0.2s;
+}
+
+input[type="text"]:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+input[type="text"]::placeholder {
+    color: var(--text-secondary);
+}
+
+button {
+    padding: 0.75rem 1.5rem;
+    background: var(--accent);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+button:hover {
+    background: var(--accent-hover);
+}
+
+button:active {
+    transform: scale(0.98);
+}
+
+#clear-btn {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 2px solid var(--border);
+}
+
+#clear-btn:hover {
+    background: var(--border);
+}
+
+#now-btn {
+    width: 100%;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 2px solid var(--border);
+}
+
+#now-btn:hover {
+    background: var(--border);
+}
+
+.loading {
+    text-align: center;
+    padding: 2rem;
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    border: 1px solid var(--border);
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    margin: 0 auto 1rem;
+    border: 4px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.error {
+    padding: 1rem 1.5rem;
+    background: rgba(255, 68, 68, 0.1);
+    border: 2px solid var(--error);
+    border-radius: 8px;
+    color: var(--error);
+    margin-bottom: 1rem;
+}
+
+.hidden {
+    display: none;
+}
+
+.results {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+@media (min-width: 1100px) {
+    .results {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+.result-section {
+    background: var(--bg-secondary);
+    padding: 1.5rem;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+}
+
+.result-section h2 {
+    font-size: 1.5rem;
+    color: var(--accent);
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.result-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.result-item:last-child {
+    border-bottom: none;
+}
+
+.result-item .label {
+    color: var(--text-secondary);
+    font-weight: 500;
+    min-width: 150px;
+    font-size: 1.05rem;
+}
+
+.result-item .value {
+    color: var(--text-primary);
+    font-family: monospace;
+    font-weight: 600;
+    text-align: right;
+    word-break: break-all;
+    font-size: 1.1rem;
+    flex: 1;
+}
+
+.copy-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 0.5rem;
+    border-radius: 6px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+    flex-shrink: 0;
+}
+
+.copy-btn:hover {
+    background: var(--bg-tertiary);
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.copy-btn:active {
+    transform: scale(0.95);
+}
+
+.copy-btn.copied {
+    color: var(--success);
+    border-color: var(--success);
+}
+
+.copy-btn svg {
+    display: block;
+}
+
+.verify-text {
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border);
+    color: var(--text-secondary);
+}
+
+footer a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+    h1 {
+        font-size: 2rem;
+    }
+
+    .input-group {
+        flex-direction: column;
+    }
+
+    .result-item {
+        flex-wrap: wrap;
+    }
+
+    .result-item .label {
+        min-width: auto;
+        flex-basis: 100%;
+    }
+
+    .result-item .value {
+        text-align: left;
+    }
+
+    .copy-btn {
+        margin-left: auto;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web-based interface for parsing datetimes and ULIDs powered by a WebAssembly module; shows UTC, formatted variants, Unix timestamps, local time, and relative time with copy controls and keyboard shortcuts.
  * Makefile targets to build the WASM artifact and serve the web UI locally.

* **Documentation**
  * Added usage and build instructions for the web interface (www/README.md).

* **Chores**
  * Updated ignore rules to exclude local WASM build artifacts.
  * Added CI workflow to build/deploy the web UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->